### PR TITLE
SSL verification callback fixes

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -623,6 +623,12 @@ func NewConsumer(conf *ConfigMap) (*Consumer, error) {
 	}
 	if v != nil {
 		c.handle.tlsConfig = v.(*tls.Config)
+		v, err = confCopy.extract("ssl.endpoint.identification.algorithm", "none")
+		if err != nil {
+			return nil, err
+		}
+		identAlgo := v.(string)
+		c.handle.verifyBrokerDNS = identAlgo == "https"
 	}
 
 	logsChanEnable, logsChan, err := confCopy.extractLogConfig()

--- a/kafka/handle.go
+++ b/kafka/handle.go
@@ -196,9 +196,10 @@ type handle struct {
 	// WaitGroup to wait for spawned go-routines to finish.
 	waitGroup sync.WaitGroup
 
-	tlsConfig     *tls.Config
-	intermediates *x509.CertPool
-	tlsLock       sync.RWMutex
+	tlsConfig       *tls.Config
+	intermediates   *x509.CertPool
+	tlsLock         sync.RWMutex
+	verifyBrokerDNS bool
 }
 
 func (h *handle) String() string {

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -533,6 +533,12 @@ func NewProducer(conf *ConfigMap) (*Producer, error) {
 	}
 	if v != nil {
 		p.handle.tlsConfig = v.(*tls.Config)
+		v, err = confCopy.extract("ssl.endpoint.identification.algorithm", "none")
+		if err != nil {
+			return nil, err
+		}
+		identAlgo := v.(string)
+		p.handle.verifyBrokerDNS = identAlgo == "https"
 	}
 
 	if int(C.rd_kafka_version()) < 0x01000000 {

--- a/kafka/tlscb.go
+++ b/kafka/tlscb.go
@@ -73,7 +73,7 @@ func goSSLCertVerifyCB(
 	}
 	chains, err := cert.Verify(verifyOpts)
 	h.tlsLock.RUnlock()
-	if len(chains) == 0 {
+	if len(chains) == 0 && err == nil {
 		err = errors.New("no path to root")
 	}
 	if err != nil {

--- a/kafka/tlscb.go
+++ b/kafka/tlscb.go
@@ -66,7 +66,7 @@ func goSSLCertVerifyCB(
 		CurrentTime:   time.Now(),
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
-	if int(depth) == 0 {
+	if int(depth) == 0 && h.verifyBrokerDNS {
 		// peer certificate - need to validate CN as well
 		// broker name can have host:port format, so split to just get host.
 		verifyOpts.DNSName = strings.Split(C.GoString(brokerName), ":")[0]


### PR DESCRIPTION
* Ensure errors from `cert.Verify` are returned correctly
* Toggle broker DNS verification based on `ssl.endpoint.identification.algorithm`