### PR TITLE
Ensure rdkafka main queue events are serviced

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -656,9 +656,7 @@ func NewConsumer(conf *ConfigMap) (*Consumer, error) {
 		return nil, newErrorFromCString(C.RD_KAFKA_RESP_ERR__INVALID_ARG, cErrstr)
 	}
 
-	if !c.readFromPartitionQueues {
-		C.rd_kafka_poll_set_consumer(c.handle.rk)
-	}
+	C.rd_kafka_poll_set_consumer(c.handle.rk)
 
 	c.handle.c = c
 	c.handle.setup()


### PR DESCRIPTION
The main rdkafka queue is where the offset commit events go; if we do
not service this queue, the events will pile up, using memory.

Also we won't know if offsets have been committed, but zendesk_kafka_go
v2 doesn't even expose an API for that.

"Service" the queue by forwarding it to the consumer queue, which we do
service.